### PR TITLE
Add http and/or https to environment variable PIHOLE_HOSTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.10-alpine
 
 RUN pip install --no-cache-dir influxdb
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ A couple of basic scripts for inserting pihole data into influxdb for graphing.
 
 Configuration options:
 ``` bash
-HOSTNAMES = "ns-01" # Pi-hole hostname(s) to report in InfluxDB for each measurement. Comma separated list.
 INFLUXDB_SERVER = "127.0.0.1" # IP or hostname to InfluxDB server
 INFLUXDB_PORT = 8086 # Port on InfluxDB server
 INFLUXDB_USERNAME = "username"
 INFLUXDB_PASSWORD = "password"
 INFLUXDB_DATABASE = "piholestats"
 DELAY = 600 # seconds
+PIHOLE_HOSTS = "ns-01" # Pi-hole hostname(s) to report in InfluxDB for each measurement. Comma separated list.
+PIHOLE_TOKENS = "token1" # Pi-hole token(s) to use to connect to the API. Comma separated list. Token can be captured from value WEBPASSWORD in setupVars.conf in /etc/pihole.
 ```
 *docker-compose.yml* - An example Docker setup to run this script
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - INFLUXDB_DATABASE=piholestats
       - DELAY=600
       - PIHOLE_HOSTS=pi.hole,pihole2
+      - PIHOLE_TOKENS=bla,bla

--- a/pihole_influx.py
+++ b/pihole_influx.py
@@ -16,7 +16,7 @@ from influxdb import InfluxDBClient
 
 # Modify these values if running as a standalone script
 _DEFAULTS = {
-    'INFLUXDB_SERVER': "http://127.0.0.1",  # IP or hostname to InfluxDB server
+    'INFLUXDB_SERVER': "127.0.0.1",  # IP or hostname to InfluxDB server
     'INFLUXDB_PORT': 8086,  # Port on InfluxDB server
     'INFLUXDB_USERNAME': "username",
     'INFLUXDB_PASSWORD': "password",
@@ -124,7 +124,7 @@ if __name__ == '__main__':
         for host in config['PIHOLE_HOSTS']:
 
             # Get PiHole Stats
-               pihole_api = "{}/admin/api.php".format(host)
+            pihole_api = "{}/admin/api.php".format(host)
             logger.info("Attempting to contact {} with URL {}".format(host, pihole_api))
             api = requests.get(pihole_api)  # URI to pihole server api
             API_out = api.json()

--- a/pihole_influx.py
+++ b/pihole_influx.py
@@ -68,14 +68,14 @@ def check_db_status(config, logger):
         config['INFLUXDB_USERNAME'],
         config['INFLUXDB_PASSWORD']
     )
-    for db in client.get_list_database():
-        if db['name'] == client:
-            logger.info('Found existing database {}.'.format(config['INFLUXDB_DATABASE']))
-            return True
-    else:
+
+    if {"name": config['INFLUXDB_DATABASE']} not in client.get_list_database():
         logger.info('Database {} not found. Will attempt to create it.'.format(config['INFLUXDB_DATABASE']))
         client.create_database(config['INFLUXDB_DATABASE'])
-    return True
+        return True
+    else:       
+        logger.info('Found existing database {}.'.format(config['INFLUXDB_DATABASE']))
+        return True
 
 
 def send_msg(config, logger, hostname, domains_being_blocked, dns_queries_today, ads_percentage_today, ads_blocked_today, unique_clients, unique_domains, status):

--- a/pihole_influx.py
+++ b/pihole_influx.py
@@ -16,7 +16,7 @@ from influxdb import InfluxDBClient
 
 # Modify these values if running as a standalone script
 _DEFAULTS = {
-    'INFLUXDB_SERVER': "127.0.0.1",  # IP or hostname to InfluxDB server
+    'INFLUXDB_SERVER': "http://127.0.0.1",  # IP or hostname to InfluxDB server
     'INFLUXDB_PORT': 8086,  # Port on InfluxDB server
     'INFLUXDB_USERNAME': "username",
     'INFLUXDB_PASSWORD': "password",
@@ -124,7 +124,7 @@ if __name__ == '__main__':
         for host in config['PIHOLE_HOSTS']:
 
             # Get PiHole Stats
-            pihole_api = "http://{}/admin/api.php".format(host)
+               pihole_api = "{}/admin/api.php".format(host)
             logger.info("Attempting to contact {} with URL {}".format(host, pihole_api))
             api = requests.get(pihole_api)  # URI to pihole server api
             API_out = api.json()

--- a/pihole_influx.py
+++ b/pihole_influx.py
@@ -4,6 +4,7 @@
 # Adapted to work with InfluxDB by /u/tollsjo in December 2016
 # Updated by Cludch December 2016
 # Updated and dockerised by rarosalion in September 2019
+# Updated by Dick Pluim December 2022 
 
 # To install and run the script as a service under SystemD. See: https://linuxconfig.org/how-to-automatically-execute-shell-script-at-startup-boot-on-systemd-linux
 
@@ -22,7 +23,8 @@ _DEFAULTS = {
     'INFLUXDB_PASSWORD': "password",
     'INFLUXDB_DATABASE': "piholestats",
     'DELAY': 600,  # seconds
-    'PIHOLE_HOSTS': ["pi.hole"]  # Pi-hole hostname(s)
+    'PIHOLE_HOSTS': ["pi.hole"],  # Pi-hole hostname(s)
+    'PIHOLE_TOKENS': [""] 
 }
 
 
@@ -42,10 +44,16 @@ def get_config():
         config[var_name] = os.getenv(var_name, _DEFAULTS[var_name])
         if var_name == 'PIHOLE_HOSTS' and ',' in config[var_name]:
             config[var_name] = config[var_name].split(',')
+        if var_name == 'PIHOLE_TOKENS' and ',' in config[var_name]:
+            config[var_name] = config[var_name].split(',')
 
     # Make sure PIHOLE_HOSTS is a list (even if it's just one entry)
     if not isinstance(config['PIHOLE_HOSTS'], list):
         config['PIHOLE_HOSTS'] = [config['PIHOLE_HOSTS']]
+
+    # Make sure PIHOLE_TOKENS is a list (even if it's just one entry)
+    if not isinstance(config['PIHOLE_TOKENS'], list):
+        config['PIHOLE_TOKENS'] = [config['PIHOLE_TOKENS']]
 
     return config
 
@@ -74,7 +82,7 @@ def send_msg(config, logger, hostname, domains_being_blocked, dns_queries_today,
     """ Sends message to InfluxDB server defined in config """
     json_body = [
         {
-            "measurement": "piholestats." + hostname.replace(".", "_"),
+            "measurement": "piholestats." + hostname.replace(".", "_").replace('https://','').replace('http://',''),
             "tags": {
                 "host": hostname
             },
@@ -111,6 +119,8 @@ if __name__ == '__main__':
 
     # Get configuration details
     config = get_config()
+    number_of_servers = len(config['PIHOLE_HOSTS'])
+    number_of_tokens = len(config['PIHOLE_TOKENS'])  # not needed actually
     logger.info("Querying {} pihole servers: {}".format(len(config['PIHOLE_HOSTS']), config['PIHOLE_HOSTS']))
     logger.info("Logging to InfluxDB server {}:{}".format(
         config['INFLUXDB_SERVER'], config['INFLUXDB_PORT']
@@ -118,14 +128,20 @@ if __name__ == '__main__':
 
     # Create database if it doesn't exist
     check_db_status(config, logger)
-
+    
     # Loop pulling stats from pihole, and pushing to influxdb
     while True:
-        for host in config['PIHOLE_HOSTS']:
-
+        i = 0
+        for i in range(number_of_servers): 
+            host = config['PIHOLE_HOSTS'][i]
+            token = config['PIHOLE_TOKENS'][i]
             # Get PiHole Stats
-            pihole_api = "{}/admin/api.php".format(host)
-            logger.info("Attempting to contact {} with URL {}".format(host, pihole_api))
+            if len(token) > 0:
+                pihole_api = "{}/admin/api.php?summaryRaw&auth={}".format(host,token)
+                logger.info("Attempting to contact {} with URL {}".format(host, pihole_api))
+            else:
+                pihole_api = "{}/admin/api.php".format(host)
+                logger.info("Attempting to contact {} with URL {}".format(host, pihole_api))
             api = requests.get(pihole_api)  # URI to pihole server api
             API_out = api.json()
             domains_being_blocked = (API_out['domains_being_blocked'])
@@ -135,6 +151,7 @@ if __name__ == '__main__':
 
             # Update DB
             send_msg(config, logger, host, domains_being_blocked, dns_queries_today, ads_percentage_today, ads_blocked_today)
+            i = i + 1
 
         # Wait...
         logger.info("Waiting {}".format(config['DELAY']))

--- a/pihole_influx.py
+++ b/pihole_influx.py
@@ -78,7 +78,7 @@ def check_db_status(config, logger):
     return True
 
 
-def send_msg(config, logger, hostname, domains_being_blocked, dns_queries_today, ads_percentage_today, ads_blocked_today):
+def send_msg(config, logger, hostname, domains_being_blocked, dns_queries_today, ads_percentage_today, ads_blocked_today, unique_clients, unique_domains, status):
     """ Sends message to InfluxDB server defined in config """
     json_body = [
         {
@@ -90,7 +90,10 @@ def send_msg(config, logger, hostname, domains_being_blocked, dns_queries_today,
                 "domains_being_blocked": int(domains_being_blocked),
                 "dns_queries_today": int(dns_queries_today),
                 "ads_percentage_today": float(ads_percentage_today),
-                "ads_blocked_today": int(ads_blocked_today)
+                "ads_blocked_today": int(ads_blocked_today),
+                "unique_clients": int(unique_clients),
+                "unique_domains": int(unique_domains),
+                "status": status
             }
         }
     ]
@@ -148,9 +151,12 @@ if __name__ == '__main__':
             dns_queries_today = (API_out['dns_queries_today'])
             ads_percentage_today = (API_out['ads_percentage_today'])
             ads_blocked_today = (API_out['ads_blocked_today'])
+            unique_clients = (API_out['unique_clients'])
+            unique_domains = (API_out['unique_domains'])
+            status = (API_out['status'])
 
             # Update DB
-            send_msg(config, logger, host, domains_being_blocked, dns_queries_today, ads_percentage_today, ads_blocked_today)
+            send_msg(config, logger, host, domains_being_blocked, dns_queries_today, ads_percentage_today, ads_blocked_today, unique_clients, unique_domains, status)
             i = i + 1
 
         # Wait...


### PR DESCRIPTION
Clarification: 

As I entered my pihole-host it wasn't found as automatically http:// was added to it, whereas I use https. Then thought of adding a variable USE_HTTPS (true or false) but with multiple pihole-instances this might also cause problems and would in my case as one is reachable from outside through https://pihole.somedomain.com whereas the other is internal with http;//<ip-adres>:<port>
